### PR TITLE
Add README with setup guide and port variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,42 @@
+# Finmars Start Page
+
+This project serves the `dist` directory via an Express server.
+
+## Prerequisites
+
+* Node.js (v22 or later recommended)
+* npm
+
+## Setup
+
+```bash
+npm install
+node server.js
+```
+
+The server listens on `PORT` (default `8080`).
+
+### Environment Variables
+
+- `KEYCLOAK_URL` – Keycloak base URL (default `https://dev-auth.finmars.com`)
+- `KEYCLOAK_REALM` – Keycloak realm (default `finmars`)
+- `KEYCLOAK_CLIENT_ID` – Keycloak client ID (default `finmars`)
+- `REDIRECT_PATH` – redirect path after login (default `/v/profile`)
+- `PORT` – HTTP port to listen on (default `8080`)
+
+Export variables before running the server, for example:
+
+```bash
+KEYCLOAK_URL=https://auth.example.com PORT=3000 node server.js
+```
+
+## Docker
+
+Build and run using Docker:
+
+```bash
+docker build -t finmars-start-page .
+docker run -p 8080:8080 finmars-start-page
+```
+
+Use `-e VAR=value` to pass environment variables into the container.

--- a/server.js
+++ b/server.js
@@ -12,6 +12,7 @@ const KEYCLOAK_URL = process.env.KEYCLOAK_URL || 'https://dev-auth.finmars.com';
 const KEYCLOAK_REALM = process.env.KEYCLOAK_REALM || 'finmars';
 const KEYCLOAK_CLIENT_ID = process.env.KEYCLOAK_CLIENT_ID || 'finmars';
 const REDIRECT_PATH = process.env.REDIRECT_PATH || '/v/profile';
+const PORT = process.env.PORT || 8080;
 
 app.use(express.static(path.join(__dirname, 'dist')));
 
@@ -50,6 +51,6 @@ app.get('/signup', function (req, res) {
 });
 
 
-app.listen(8080, '0.0.0.0', function () {
-    console.info('Express server start at 8080 port');
+app.listen(PORT, '0.0.0.0', function () {
+    console.info(`Express server start at ${PORT} port`);
 });


### PR DESCRIPTION
## Summary
- document setup and Docker usage in README
- support configurable port via `PORT` env var

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_b_6868119bda74832d83bb86293c9cf986